### PR TITLE
build: refresh dependencies and verify Paper 1.21.11 startup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.6.0
         with:
           path: build/libs/**.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.6.0
         with:
           path: build/libs/**.jar
       - name: Generating Changelog

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,13 +89,34 @@ tasks {
         }
     }
     runServer {
-        minecraftVersion("1.20.4")
+        minecraftVersion("1.21.11")
     }
 }
 
 tasks.getByName("modrinth").dependsOn(tasks.modrinthSyncBody)
 
-val versions = listOf("1.19.4", "1.20", "1.20.1", "1.20.2", "1.20.3", "1.20.4", "1.20.5", "1.20.6", "1.21", "1.21.1", "1.21.2", "1.21.3");
+val versions = listOf(
+    "1.19.4",
+    "1.20",
+    "1.20.1",
+    "1.20.2",
+    "1.20.3",
+    "1.20.4",
+    "1.20.5",
+    "1.20.6",
+    "1.21",
+    "1.21.1",
+    "1.21.2",
+    "1.21.3",
+    "1.21.4",
+    "1.21.5",
+    "1.21.6",
+    "1.21.7",
+    "1.21.8",
+    "1.21.9",
+    "1.21.10",
+    "1.21.11"
+)
 
 modrinth {
     token.set(System.getenv("MODRINTH_TOKEN"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,30 +1,30 @@
 [versions]
 minecraft = "1.20.4-R0.1-SNAPSHOT"
-adventure = "4.3.4"
-minimessage = "4.17.0"
+adventure = "4.4.1"
+minimessage = "4.26.1"
 [plugins]
-userdev = { id = "io.papermc.paperweight.userdev", version = "1.7.4" }
+userdev = { id = "io.papermc.paperweight.userdev", version = "1.7.7" }
 runpaper = { id = "xyz.jpenilla.run-paper", version = "2.3.1" }
-shadow = { id = "com.gradleup.shadow", version = "8.3.3" }
-lombok = { id = "io.freefair.lombok", version = "8.10.2" }
-hangar = { id = "io.papermc.hangar-publish-plugin", version = "0.1.2" }
-minotaur = { id = "com.modrinth.minotaur", version = "2.8.7" }
+shadow = { id = "com.gradleup.shadow", version = "8.3.5" }
+lombok = { id = "io.freefair.lombok", version = "9.2.0" }
+hangar = { id = "io.papermc.hangar-publish-plugin", version = "0.1.4" }
+minotaur = { id = "com.modrinth.minotaur", version = "2.8.10" }
 paperyml = { id = "net.minecrell.plugin-yml.paper", version = "0.6.0" }
 pluginyml = { id = "net.minecrell.plugin-yml.bukkit", version = "0.6.0" }
 [libraries]
 spigot = { module = "org.spigotmc:spigot-api", version = "1.20.4-R0.1-SNAPSHOT" }
 paper = { module = "io.papermc.paper:paper-api", version = "1.20.4-R0.1-SNAPSHOT" }
 
-annotations = { module = "org.jetbrains:annotations", version = "26.0.1" }
-jedis = { module = "redis.clients:jedis", version = "5.1.5" }
+annotations = { module = "org.jetbrains:annotations", version = "26.1.0" }
+jedis = { module = "redis.clients:jedis", version = "7.3.0" }
 miniplaceholders = { module = "io.github.miniplaceholders:miniplaceholders-api", version = "2.2.3" }
 commandframework = { module = "cloud.commandframework:cloud-paper", version = "1.8.4" }
-configlib = { module = "de.exlll:configlib-yaml", version = "4.5.0" }
+configlib = { module = "de.exlll:configlib-yaml", version = "4.8.1" }
 guice = { module = "com.google.inject:guice", version = "7.0.0" }
-luckperms = { module = "net.luckperms:api", version = "5.4" }
-bstats = { module = "org.bstats:bstats-bukkit", version = "3.1.0" }
-hikaridb = { module = "com.zaxxer:HikariCP", version = "6.0.0" }
-placeholderapi = { module = "me.clip:placeholderapi", version = "2.11.6" }
+luckperms = { module = "net.luckperms:api", version = "5.5" }
+bstats = { module = "org.bstats:bstats-bukkit", version = "3.2.1" }
+hikaridb = { module = "com.zaxxer:HikariCP", version = "7.0.2" }
+placeholderapi = { module = "me.clip:placeholderapi", version = "2.12.2" }
 stringsimilarity = { module = "net.ricecode:string-similarity", version = "1.0.0" }
 ultrapermissions = { module = "me.TechsCode:UltraPermissionsAPI", version = "5.5.2" }
 

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -11,3 +11,10 @@ dependencies {
     compileOnly(libs.paper)
     compileOnly(libs.guice)
 }
+
+tasks {
+    compileJava {
+        options.release.set(17)
+        options.encoding = Charsets.UTF_8.name()
+    }
+}


### PR DESCRIPTION
## Summary
- refresh Gradle plugin and library versions in `gradle/libs.versions.toml` while keeping `spigot-api`/`paper-api` on 1.20.4 for 1.19.4+ compatibility
- update build metadata targets in `build.gradle.kts` to include support listings up to 1.21.11 and run local test server with 1.21.11
- pin `paper` subproject Java compilation to release 17 and update GitHub workflow artifact action to `actions/upload-artifact@v4.6.0`

## Validation
- `./gradlew clean build`
- `./gradlew runServer --rerun` (Paper `1.21.11`, plugin loads and enables successfully)